### PR TITLE
Tweak for v0.14 compatible layer

### DIFF
--- a/fluent-plugin-resolv.gemspec
+++ b/fluent-plugin-resolv.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "fluentd"
-  spec.add_runtime_dependency "fluentd"
+  spec.add_development_dependency "test-unit", "~> 3.2.0"
+  spec.add_runtime_dependency "fluentd", [">= 0.12.0", "< 2"]
 end

--- a/lib/fluent/plugin/out_resolv.rb
+++ b/lib/fluent/plugin/out_resolv.rb
@@ -17,10 +17,9 @@ class Fluent::ResolvOutput < Fluent::Output
     tag = (@add_prefix + '.' + tag) if @add_prefix
     es.each do |time,record|
       record[@key_name] = Resolv.getname(record[@key_name]) rescue record[@key_name].empty? ? 'n/a' : record[@key_name]
-      Fluent::Engine.emit(tag, time, record)
+      router.emit(tag, time, record)
     end
     chain.next
   end
 
 end
-


### PR DESCRIPTION
Because this plugin is not v0.14 ready.

* Please use `router#emit` instead of `Engine.emit` because v0.14 treats it as a bug.
* Depends on test-unit gem explicitly